### PR TITLE
use ActiveSpanManager to get current camel span and establish current OTel context

### DIFF
--- a/camel-kafka-demo-consumer/src/main/java/com/iaa/camelkafkademoconsumer/CamelRouteBuilder.java
+++ b/camel-kafka-demo-consumer/src/main/java/com/iaa/camelkafkademoconsumer/CamelRouteBuilder.java
@@ -15,7 +15,7 @@ public class CamelRouteBuilder extends RouteBuilder {
   public void configure() throws Exception {
     from("kafka:viewedpages?brokers=localhost:9092")
       .process(exchange -> {
-        try (AutoCloseable closeyMcCloserson = ActiveSpanManager.getSpan(exchange).makeCurrent()) {
+        try (AutoCloseable scope = ActiveSpanManager.getSpan(exchange).makeCurrent()) {
           modifyBody(exchange);
         }
       })

--- a/camel-kafka-demo-consumer/src/main/java/com/iaa/camelkafkademoconsumer/CamelRouteBuilder.java
+++ b/camel-kafka-demo-consumer/src/main/java/com/iaa/camelkafkademoconsumer/CamelRouteBuilder.java
@@ -1,29 +1,35 @@
 package com.iaa.camelkafkademoconsumer;
 
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.tracing.ActiveSpanManager;
 import org.springframework.stereotype.Component;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 @Component
 public class CamelRouteBuilder extends RouteBuilder {
+
   @Override
   public void configure() throws Exception {
-    // from("timer:foo").to("log:bar");
     from("kafka:viewedpages?brokers=localhost:9092")
-        // .process(new TraceEnrichingProcessor(null))
-        .process(expression -> {
-          Tracer tracer = GlobalOpenTelemetry.getTracer("camel-consumer-tracer");
-          Span mapperSpan = tracer.spanBuilder("consumer-mapper").startSpan();
-          // Custom processing logic
-          String body = expression.getIn().getBody(String.class);
-          String modifiedBody = "Processed: " + body;
-          expression.getIn().setBody(modifiedBody);
-          mapperSpan.end();
-        })
-        .to("kafka:processedviews?brokers=localhost:9092")
-        .to("log:processedviews");
+      .process(exchange -> {
+        try (AutoCloseable closeyMcCloserson = ActiveSpanManager.getSpan(exchange).makeCurrent()) {
+          modifyBody(exchange);
+        }
+      })
+      .to("kafka:processedviews?brokers=localhost:9092")
+      .to("log:processedviews");
+  }
+
+  @WithSpan("consumer-mapper")
+  private void modifyBody(Exchange exchange) {
+    Span span = Span.current();
+    String body = exchange.getIn().getBody(String.class);
+    span.setAttribute("app.body.original", body);
+    String modifiedBody = "Processed: " + body;
+		span.setAttribute("app.body.modified", modifiedBody);
+    exchange.getIn().setBody(modifiedBody);
   }
 }

--- a/camel-kafka-demo-producer/src/main/java/com/iaa/camelkafkademoproducer/CamelRouteBuilder.java
+++ b/camel-kafka-demo-producer/src/main/java/com/iaa/camelkafkademoproducer/CamelRouteBuilder.java
@@ -20,7 +20,7 @@ public class CamelRouteBuilder extends RouteBuilder {
         // camel-opentelemetry doesn't seem to provide a way to get the current span.
         OpenTelemetrySpanAdapter camelSpan = (OpenTelemetrySpanAdapter) ActiveSpanManager.getSpan(exchange);
 
-        try (AutoCloseable closeyMcCloserson = camelSpan.makeCurrent()) {
+        try (AutoCloseable scope = camelSpan.makeCurrent()) {
           // Custom processing logic
           modifyBody(exchange);
         }


### PR DESCRIPTION
Also instrument the custom logic of process by moving it to a private method and use the WithSpan annotation to create the span. This is smoother than the try-catch-finally syntax to manage a span created in-line.